### PR TITLE
Update CounterStrikeSharp API references to 1.0.305

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This plugin is similar to the CS:GO version.
 
 > [!NOTE]  
-> Required CSSharp version: **303**
+> Required CSSharp version: **305**
 
 # API
 

--- a/src/AntiDLL.API/AntiDLL.API.csproj
+++ b/src/AntiDLL.API/AntiDLL.API.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.303" />
+    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.305" />
   </ItemGroup>
 
 </Project>

--- a/src/AntiDLL.BanModule/AntiDLL.BanModule.csproj
+++ b/src/AntiDLL.BanModule/AntiDLL.BanModule.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.303" />
+    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.305" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AntiDLL.Example/AntiDLL.Example.csproj
+++ b/src/AntiDLL.Example/AntiDLL.Example.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.303" />
+    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.305" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AntiDLL/Plugin/PluginManifest.cs
+++ b/src/AntiDLL/Plugin/PluginManifest.cs
@@ -3,7 +3,7 @@
     using CounterStrikeSharp.API.Core;
     using CounterStrikeSharp.API.Core.Attributes;
 
-    [MinimumApiVersion(version: 303)]
+    [MinimumApiVersion(version: 305)]
     public sealed partial class Plugin : BasePlugin
     {
         public override string ModuleName => "CS2 AntiDLL";


### PR DESCRIPTION
## Summary
- align all project references on CounterStrikeSharp.API to version 1.0.305
- raise the plugin minimum API version to match the new dependency
- document the updated CSSharp requirement in the README

## Testing
- `dotnet build` *(fails: `dotnet` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0812c3d4832288774cb3e4d4b367